### PR TITLE
Put try/catch around the call of ws.send() in lib/WebSockerServer.js.

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -73,7 +73,10 @@ function handleConnection (input, output, ws) {
         return;
       case 'Message':
         if (command.id === id) {
-          ws.send(command.message);
+          try {
+            ws.send(command.message);
+          } catch (err) {
+          }
         };
         return;
       default:


### PR DESCRIPTION
This protects against the client closing the socket just as the server is about to send a message. Since ws.send() can throw, its callers need to catch.

This was causing my server to crash when I sent a chat message that I was using to also disable the WebSocket subscription, so I could test recovery from the connection going down.

The throw in ws.send is [here](https://github.com/websockets/ws/blob/942f825ff0702ce7ce66d8731a56b071269d88b4/lib/WebSocket.js#L355).

My client code that caused the crash is [here](https://github.com/billstclair/spokes/blob/9498e5a195d9910341c2be7fd1e4eaad766e44e6/src/Spokes.elm#L224), when text is "disconnect".